### PR TITLE
Small improvement in local images option

### DIFF
--- a/adm/style/acp_seo_metadata_settings.html
+++ b/adm/style/acp_seo_metadata_settings.html
@@ -91,8 +91,8 @@
 				<br><span>{{ lang('ACP_SEO_METADATA_LOCAL_IMAGES_EXPLAIN', SERVER_NAME) }}</span>
 			</dt>
 			<dd>
-				<label><input type="radio" id="seo_metadata_local_images" name="seo_metadata_local_images" value="1"{% if SEO_METADATA_LOCAL_IMAGES %} checked="checked"{% endif %}> {{ lang('YES') }}</label>
-				<label><input type="radio" name="seo_metadata_local_images" value="0"{% if not SEO_METADATA_LOCAL_IMAGES %} checked="checked"{% endif %}> {{ lang('NO') }}</label>
+				<label><input type="radio" id="seo_metadata_local_images" name="seo_metadata_local_images" value="1"{% if SEO_METADATA_LOCAL_IMAGES %} checked="checked"{% endif %}{% if not SERVER_NAME %} disabled="disabled"{% endif %}> {{ lang('YES') }}</label>
+				<label><input type="radio" name="seo_metadata_local_images" value="0"{% if not SEO_METADATA_LOCAL_IMAGES %} checked="checked"{% endif %}{% if not SERVER_NAME %} disabled="disabled"{% endif %}> {{ lang('NO') }}</label>
 			</dd>
 		</dl>
 		<dl>

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -563,7 +563,7 @@ class helper
 		$max_images = abs((int) $max_images);
 		$max_images = empty($max_images) ? 5 : $max_images;
 		$max_images = ($max_images > 5) ? 5 : $max_images;
-		$server_name = $this->config['server_name'];
+		$server_name = trim($this->config['server_name']);
 		$images = [];
 
 		// Ensure it's XML
@@ -599,7 +599,9 @@ class helper
 			}
 
 			// Get only local images
-			if ($local_images && !preg_match('#^https?://(?:\w+\.)?' . preg_quote($server_name) . '#', $url))
+			if ($local_images &&
+				!empty($server_name) &&
+				!preg_match('#^https?://(?:\w+\.)?' . preg_quote($server_name) . '#', $url))
 			{
 				continue;
 			}


### PR DESCRIPTION
It disables the "Local images" option in the ACP if the server name, for some reason, is empty.