### PR TITLE
Improve ACP form settings validation

### DIFF
--- a/adm/style/acp_seo_metadata_settings.html
+++ b/adm/style/acp_seo_metadata_settings.html
@@ -6,6 +6,14 @@
 	<p>{{ lang('ACP_SEO_METADATA_EXPLAIN') }}</p>
 </div>
 
+{% if VALIDATION_ERRORS %}
+<div class="errorbox">
+	{% for ERROR in VALIDATION_ERRORS %}
+	<p>{{ ERROR.MESSAGE }}</p>
+	{% endfor %}
+</div>
+{% endif %}
+
 <form id="seo_metadata_settings" method="POST" action="{{ U_ACTION }}">
 
 	<fieldset>
@@ -144,7 +152,7 @@
 				<br><span>{{ lang('ACP_FACEBOOK_PUBLISHER_EXPLAIN') }}</span>
 			</dt>
 			<dd>
-				<input type="text" id="seo_metadata_facebook_publisher" name="seo_metadata_facebook_publisher"{% if SEO_METADATA_FACEBOOK_PUBLISHER %} value="{{ SEO_METADATA_FACEBOOK_PUBLISHER }}"{% endif %} class="full">
+				<input type="url" id="seo_metadata_facebook_publisher" name="seo_metadata_facebook_publisher"{% if SEO_METADATA_FACEBOOK_PUBLISHER %} value="{{ SEO_METADATA_FACEBOOK_PUBLISHER }}"{% endif %} class="full">
 			</dd>
 		</dl>
 	</fieldset>

--- a/adm/style/acp_seo_metadata_settings.html
+++ b/adm/style/acp_seo_metadata_settings.html
@@ -17,7 +17,7 @@
 <form id="seo_metadata_settings" method="POST" action="{{ U_ACTION }}">
 
 	<fieldset>
-		<legend>{{ lang('ACP_GLOBAL_SETTINGS') }}</legend>
+		<legend>{{ lang('ACP_SEO_METADATA_GLOBAL_SETTINGS') }}</legend>
 		<dl>
 			<dt>
 				<label for="seo_metadata_meta_description">{{ lang('ACP_SEO_METADATA_META_DESCRIPTION') }}{{ lang('COLON') }}</label>
@@ -126,10 +126,10 @@
 	</fieldset>
 
 	<fieldset>
-		<legend>{{ lang('ACP_OPEN_GRAPH_SETTINGS') }}</legend>
+		<legend>{{ lang('ACP_SEO_METADATA_OPEN_GRAPH_SETTINGS') }}</legend>
 		<dl>
 			<dt>
-				<label for="seo_metadata_open_graph">{{ lang('ACP_OPEN_GRAPH') }}{{ lang('COLON') }}</label>
+				<label for="seo_metadata_open_graph">{{ lang('ACP_SEO_METADATA_OPEN_GRAPH') }}{{ lang('COLON') }}</label>
 				<br><span>{{ lang('ACP_SEO_METADATA_DATA_EXPLAIN') }}</span>
 			</dt>
 			<dd>
@@ -139,8 +139,8 @@
 		</dl>
 		<dl>
 			<dt>
-				<label for="seo_metadata_facebook_application">{{ lang('ACP_FACEBOOK_APPLICATION') }}{{ lang('COLON') }}</label>
-				<br><span>{{ lang('ACP_FACEBOOK_APPLICATION_EXPLAIN') }}</span>
+				<label for="seo_metadata_facebook_application">{{ lang('ACP_SEO_METADATA_FACEBOOK_APPLICATION') }}{{ lang('COLON') }}</label>
+				<br><span>{{ lang('ACP_SEO_METADATA_FACEBOOK_APPLICATION_EXPLAIN') }}</span>
 			</dt>
 			<dd>
 				<input type="text" id="seo_metadata_facebook_application" name="seo_metadata_facebook_application"{% if SEO_METADATA_FACEBOOK_APPLICATION %} value="{{ SEO_METADATA_FACEBOOK_APPLICATION }}"{% endif %} class="full">
@@ -148,8 +148,8 @@
 		</dl>
 		<dl>
 			<dt>
-				<label for="seo_metadata_facebook_publisher">{{ lang('ACP_FACEBOOK_PUBLISHER') }}{{ lang('COLON') }}</label>
-				<br><span>{{ lang('ACP_FACEBOOK_PUBLISHER_EXPLAIN') }}</span>
+				<label for="seo_metadata_facebook_publisher">{{ lang('ACP_SEO_METADATA_FACEBOOK_PUBLISHER') }}{{ lang('COLON') }}</label>
+				<br><span>{{ lang('ACP_SEO_METADATA_FACEBOOK_PUBLISHER_EXPLAIN') }}</span>
 			</dt>
 			<dd>
 				<input type="url" id="seo_metadata_facebook_publisher" name="seo_metadata_facebook_publisher"{% if SEO_METADATA_FACEBOOK_PUBLISHER %} value="{{ SEO_METADATA_FACEBOOK_PUBLISHER }}"{% endif %} class="full">
@@ -158,10 +158,10 @@
 	</fieldset>
 
 	<fieldset>
-		<legend>{{ lang('ACP_TWITTER_CARD_SETTINGS') }}</legend>
+		<legend>{{ lang('ACP_SEO_METADATA_TWITTER_CARD_SETTINGS') }}</legend>
 		<dl>
 			<dt>
-				<label for="seo_metadata_twitter_cards">{{ lang('ACP_TWITTER_CARDS') }}{{ lang('COLON') }}</label>
+				<label for="seo_metadata_twitter_cards">{{ lang('ACP_SEO_METADATA_TWITTER_CARDS') }}{{ lang('COLON') }}</label>
 				<br><span>{{ lang('ACP_SEO_METADATA_DATA_EXPLAIN') }}</span>
 			</dt>
 			<dd>
@@ -171,8 +171,8 @@
 		</dl>
 		<dl>
 			<dt>
-				<label for="seo_metadata_twitter_publisher">{{ lang('ACP_TWITTER_PUBLISHER') }}{{ lang('COLON') }}</label>
-				<br><span>{{ lang('ACP_TWITTER_PUBLISHER_EXPLAIN') }}</span>
+				<label for="seo_metadata_twitter_publisher">{{ lang('ACP_SEO_METADATA_TWITTER_PUBLISHER') }}{{ lang('COLON') }}</label>
+				<br><span>{{ lang('ACP_SEO_METADATA_TWITTER_PUBLISHER_EXPLAIN') }}</span>
 			</dt>
 			<dd>
 				<input type="text" id="seo_metadata_twitter_publisher" name="seo_metadata_twitter_publisher"{% if SEO_METADATA_TWITTER_PUBLISHER %} value="{{ SEO_METADATA_TWITTER_PUBLISHER }}"{% endif %} class="full">
@@ -181,10 +181,10 @@
 	</fieldset>
 
 	<fieldset>
-		<legend>{{ lang('ACP_JSON_LD_SETTINGS') }}</legend>
+		<legend>{{ lang('ACP_SEO_METADATA_JSON_LD_SETTINGS') }}</legend>
 		<dl>
 			<dt>
-				<label for="seo_metadata_json_ld">{{ lang('ACP_JSON_LD') }}{{ lang('COLON') }}</label>
+				<label for="seo_metadata_json_ld">{{ lang('ACP_SEO_METADATA_JSON_LD') }}{{ lang('COLON') }}</label>
 				<br><span>{{ lang('ACP_SEO_METADATA_DATA_EXPLAIN') }}</span>
 			</dt>
 			<dd>

--- a/controller/acp.php
+++ b/controller/acp.php
@@ -97,6 +97,86 @@ class acp
 			'dimensions'
 		];
 
+		// Validation errors
+		$errors = [];
+
+		// Field filters
+		$filters = [
+			// Global
+			'seo_metadata_meta_description' => [
+				'filter' => FILTER_VALIDATE_BOOLEAN
+			],
+			'seo_metadata_desc_length' => [
+				'filter' => FILTER_VALIDATE_INT,
+				'min_range' => 50,
+				'max_range' => 255
+			],
+			'seo_metadata_desc_strategy' => [
+				'filter' => FILTER_VALIDATE_INT,
+				'min_range' => 0,
+				'max_range' => 2
+			],
+			'seo_metadata_image_strategy' => [
+				'filter' => FILTER_VALIDATE_INT,
+				'min_range' => 0,
+				'max_range' => 1
+			],
+			'seo_metadata_default_image' => [
+				'filter' => FILTER_VALIDATE_REGEXP,
+				'regexp' => '#^[\w\.\-\/]+\.(?:jpe?g|png|gif)$#'
+			],
+			'seo_metadata_default_image_width' => [
+				'filter' => FILTER_VALIDATE_INT,
+				'min_range' => 200,
+				'max_range' => 1000
+			],
+			'seo_metadata_default_image_height' => [
+				'filter' => FILTER_VALIDATE_INT,
+				'min_range' => 200,
+				'max_range' => 1000
+			],
+			'seo_metadata_default_image_type' => [
+				'filter' => FILTER_VALIDATE_REGEXP,
+				'regexp' => '#^image\/(?:jpe?g|png|gif)$#'
+			],
+			'seo_metadata_local_images' => [
+				'filter' => FILTER_VALIDATE_BOOLEAN
+			],
+			'seo_metadata_attachments' => [
+				'filter' => FILTER_VALIDATE_BOOLEAN
+			],
+			'seo_metadata_prefer_attachments' => [
+				'filter' => FILTER_VALIDATE_BOOLEAN
+			],
+
+			// Open Graph
+			'seo_metadata_open_graph' => [
+				'filter' => FILTER_VALIDATE_BOOLEAN
+			],
+			'seo_metadata_facebook_application' => [
+				'filter' => FILTER_VALIDATE_REGEXP,
+				'regexp' => '#^\d{10,25}$#'
+			],
+			'seo_metadata_facebook_publisher' => [
+				'filter' => FILTER_VALIDATE_REGEXP,
+				'regexp' => '#^https?://(?:www\.)?facebook\.com\/(?:pages\/)?[\w\.\-]+$#'
+			],
+
+			// Twitter Cards
+			'seo_metadata_twitter_cards' => [
+				'filter' => FILTER_VALIDATE_BOOLEAN
+			],
+			'seo_metadata_twitter_publisher' => [
+				'filter' => FILTER_VALIDATE_REGEXP,
+				'regexp' => '#^\@[\w\.\-]+$#'
+			],
+
+			// JSON-LD
+			'seo_metadata_json_ld' => [
+				'filter' => FILTER_VALIDATE_BOOLEAN
+			]
+		];
+
 		// Request form data
 		if ($this->request->is_set_post('submit'))
 		{
@@ -109,185 +189,130 @@ class acp
 				);
 			}
 
-			// Meta description
-			$meta_description = $this->request->variable('seo_metadata_meta_description', 1);
-			$meta_description = (in_array($meta_description, [0, 1], true)) ? $meta_description : 1;
-			$this->config->set(
-				'seo_metadata_meta_description',
-				$meta_description
-			);
+			// Form data
+			$fields = [
+				// Global
+				'seo_metadata_meta_description' => $this->request->variable(
+					'seo_metadata_meta_description',
+					1
+				),
+				'seo_metadata_desc_length' => $this->request->variable(
+					'seo_metadata_desc_length',
+					160
+				),
+				'seo_metadata_desc_strategy' => $this->request->variable(
+					'seo_metadata_desc_strategy',
+					0
+				),
+				'seo_metadata_image_strategy' => $this->request->variable(
+					'seo_metadata_image_strategy',
+					0
+				),
+				'seo_metadata_default_image' => $this->request->variable(
+					'seo_metadata_default_image',
+					''
+				),
+				'seo_metadata_default_image_width' => $this->request->variable(
+					'seo_metadata_default_image_width',
+					0
+				),
+				'seo_metadata_default_image_height' => $this->request->variable(
+					'seo_metadata_default_image_height',
+					0
+				),
+				'seo_metadata_default_image_type' => $this->request->variable(
+					'seo_metadata_default_image_type',
+					''
+				),
+				'seo_metadata_local_images' => $this->request->variable(
+					'seo_metadata_local_images',
+					1
+				),
+				'seo_metadata_attachments' => $this->request->variable(
+					'seo_metadata_attachments',
+					0
+				),
+				'seo_metadata_prefer_attachments' => $this->request->variable(
+					'seo_metadata_prefer_attachments',
+					0
+				),
 
-			// Description length
-			$desc_length = $this->request->variable('seo_metadata_desc_length', 160);
-			$desc_length = ($desc_length < 50) ? 50 : $desc_length;
-			$desc_length = ($desc_length > 255) ? 255 : $desc_length;
-			$this->config->set(
-				'seo_metadata_desc_length',
-				$desc_length
-			);
+				// Open Graph
+				'seo_metadata_open_graph' => $this->request->variable(
+					'seo_metadata_open_graph',
+					1
+				),
+				'seo_metadata_facebook_application' => $this->request->variable(
+					'seo_metadata_facebook_application',
+					''
+				),
+				'seo_metadata_facebook_publisher' => $this->request->variable(
+					'seo_metadata_facebook_publisher',
+					''
+				),
 
-			// Description strategy
-			$desc_strategy = $this->request->variable('seo_metadata_desc_strategy', 0);
-			$desc_strategy = (in_array($desc_strategy, array_keys($desc_strategies), true)) ? $desc_strategy : 0;
-			$this->config->set(
-				'seo_metadata_desc_strategy',
-				$desc_strategy
-			);
+				// Twitter Cards
+				'seo_metadata_twitter_cards' => $this->request->variable(
+					'seo_metadata_twitter_cards',
+					1
+				),
+				'seo_metadata_twitter_publisher' => $this->request->variable(
+					'seo_metadata_twitter_publisher',
+					''
+				),
 
-			// Image strategy
-			$image_strategy = $this->request->variable('seo_metadata_image_strategy', 0);
-			$image_strategy = (in_array($image_strategy, array_keys($image_strategies), true)) ? $image_strategy : 0;
-			$this->config->set(
-				'seo_metadata_image_strategy',
-				$image_strategy
-			);
-
-			// Default image
-			$default_image = $this->request->variable('seo_metadata_default_image', '');
-			$this->config->set(
-				'seo_metadata_default_image',
-				$default_image
-			);
-
-			// Default image information
-			$default_image_info = [
-				'width' => $this->request->variable('seo_metadata_default_image_width', 0),
-				'height' => $this->request->variable('seo_metadata_default_image_height', 0),
-				'type' => $this->request->variable('seo_metadata_default_image_type', '')
+				// JSON-LD
+				'seo_metadata_json_ld' => $this->request->variable(
+					'seo_metadata_json_ld',
+					1
+				)
 			];
 
-			// Default image URL
-			// Also acts as validator
-			$default_image_url = !empty($default_image) ? $this->helper->clean_image($default_image) : '';
-
-			// Try to get image width, height and type
-			if (empty($default_image_info['width']) || empty($default_image_info['height']) || empty($default_image_info['type']))
+			// Convert default image filename to URL
+			if (!empty($fields['seo_metadata_default_image']))
 			{
-				if (!empty($default_image) && !empty($default_image_url))
-				{
-					$default_image_info = $this->imagesize->getImageSize($default_image_url);
-				}
-
-				// Get MIME type as string
-				if (!empty($default_image_info['type']) && is_int($default_image_info['type']))
-				{
-					$default_image_info['type'] = image_type_to_mime_type($default_image_info['type']);
-				}
+				$fields['seo_metadata_default_image'] = $this->helper->clean_image(
+					$fields['seo_metadata_default_image']
+				);
 			}
 
-			// Validate default image information
-			$valid_image_info = !empty($default_image_url) &&
-				!empty($default_image_info) &&
-				$default_image_info['width'] >= 200 &&
-				$default_image_info['height'] >= 200 &&
-				!empty($default_image_info['type']);
-
-			// Default image information
-			if ($valid_image_info)
+			// Add "@" before the Twitter username
+			if (!empty($fields['seo_metadata_twitter_publisher']))
 			{
-				foreach ($default_image_info as $key => $value)
+				if (strpos($fields['seo_metadata_twitter_publisher']) === false)
 				{
-					if (!in_array($key, ['width', 'height', 'type'], true))
-					{
-						continue;
-					}
-
-					$this->config->set(
-						sprintf('seo_metadata_default_image_%s', $key),
-						$value
+					$fields['seo_metadata_twitter_publisher'] = sprintf(
+						'@%s',
+						$fields['seo_metadata_twitter_publisher']
 					);
 				}
 			}
 
-			// Local images
-			$local_images = $this->request->variable('seo_metadata_local_images', 1);
-			$local_images = (in_array($local_images, [0, 1], true)) ? $local_images : 1;
-			$this->config->set(
-				'seo_metadata_local_images',
-				$local_images
-			);
-
-			// Include attachments
-			$use_attachments = $this->request->variable('seo_metadata_attachments', 0);
-			$use_attachments = (in_array($use_attachments, [0, 1], true)) ? $use_attachments : 0;
-			$this->config->set(
-				'seo_metadata_attachments',
-				$use_attachments
-			);
-
-			// Prefer attachments
-			$prefer_attachments = $this->request->variable('seo_metadata_prefer_attachments', 0);
-			$prefer_attachments = (in_array($prefer_attachments, [0, 1], true)) ? $prefer_attachments : 0;
-			$this->config->set(
-				'seo_metadata_prefer_attachments',
-				$prefer_attachments
-			);
-
-			// Open Graph
-			$open_graph = $this->request->variable('seo_metadata_open_graph', 1);
-			$open_graph = (in_array($open_graph, [0, 1], true)) ? $open_graph : 1;
-			$this->config->set(
-				'seo_metadata_open_graph',
-				$open_graph
-			);
-
-			// Facebook application ID
-			$this->config->set(
-				'seo_metadata_facebook_application',
-				$this->request->variable('seo_metadata_facebook_application', 0)
-			);
-
-			// Facebook publisher
-			$this->config->set(
-				'seo_metadata_facebook_publisher',
-				$this->request->variable('seo_metadata_facebook_publisher', '')
-			);
-
-			// Twitter Cards
-			$twitter_cards = $this->request->variable('seo_metadata_twitter_cards', 1);
-			$twitter_cards = (in_array($twitter_cards, [0, 1], true)) ? $twitter_cards : 1;
-			$this->config->set(
-				'seo_metadata_twitter_cards',
-				$twitter_cards
-			);
-
-			// Twitter publisher
-			$twitter_publisher = $this->request->variable('seo_metadata_twitter_publisher', '');
-
-			// Add "@" before the Twitter username
-			if (!empty($twitter_publisher) && strpos($twitter_publisher, '@') === false)
+			// Validation check
+			if ($this->helper->validate($fields, $filters, $errors))
 			{
-				$twitter_publisher = sprintf('@%s', $twitter_publisher);
+				// Save configuration
+				foreach ($fields as $key => $value)
+				{
+					$this->config->set($key, $value);
+				}
+
+				// Admin log
+				$this->log->add(
+					'admin',
+					$this->user->data['user_id'],
+					$this->user->ip,
+					'LOG_SEO_METADATA_DATA',
+					false,
+					[$this->language->lang('SETTINGS')]
+				);
+
+				// Confirm dialog
+				trigger_error(
+					$this->language->lang('CONFIG_UPDATED') .
+					adm_back_link($u_action)
+				);
 			}
-
-			$this->config->set(
-				'seo_metadata_twitter_publisher',
-				$twitter_publisher
-			);
-
-			// JSON-LD
-			$json_ld = $this->request->variable('seo_metadata_json_ld', 1);
-			$json_ld = (in_array($json_ld, [0, 1], true)) ? $json_ld : 1;
-			$this->config->set(
-				'seo_metadata_json_ld',
-				$json_ld
-			);
-
-			// Admin log
-			$this->log->add(
-				'admin',
-				$this->user->data['user_id'],
-				$this->user->ip,
-				'LOG_SEO_METADATA_DATA',
-				false,
-				[$this->language->lang('SETTINGS')]
-			);
-
-			// Confirm dialog
-			trigger_error(
-				$this->language->lang('CONFIG_UPDATED') .
-				adm_back_link($u_action)
-			);
 		}
 
 		// Assign template variables
@@ -328,6 +353,14 @@ class acp
 				'NAME' => $this->language->lang(sprintf('ACP_SEO_METADATA_IMAGE_%s', strtoupper($value))),
 				'VALUE' => $key,
 				'SELECTED' => ($key === (int) $this->config['seo_metadata_image_strategy'])
+			]);
+		}
+
+		// Validation errors
+		foreach ($errors as $key => $value)
+		{
+			$this->template->assign_block_vars('VALIDATION_ERRORS', [
+				'MESSAGE' => $value['message']
 			]);
 		}
 	}

--- a/controller/acp.php
+++ b/controller/acp.php
@@ -108,36 +108,50 @@ class acp
 			],
 			'seo_metadata_desc_length' => [
 				'filter' => FILTER_VALIDATE_INT,
-				'min_range' => 50,
-				'max_range' => 255
+				'options' => [
+					'min_range' => 50,
+					'max_range' => 255
+				]
 			],
 			'seo_metadata_desc_strategy' => [
 				'filter' => FILTER_VALIDATE_INT,
-				'min_range' => 0,
-				'max_range' => 2
+				'options' => [
+					'min_range' => 0,
+					'max_range' => 2
+				]
 			],
 			'seo_metadata_image_strategy' => [
 				'filter' => FILTER_VALIDATE_INT,
-				'min_range' => 0,
-				'max_range' => 1
+				'options' => [
+					'min_range' => 0,
+					'max_range' => 1
+				]
 			],
 			'seo_metadata_default_image' => [
 				'filter' => FILTER_VALIDATE_REGEXP,
-				'regexp' => '#^[\w\.\-\/]+\.(?:jpe?g|png|gif)$#'
+				'options' => [
+					'regexp' => '#^[\w\.\-\/]+\.(?:jpe?g|png|gif)$#'
+				]
 			],
 			'seo_metadata_default_image_width' => [
 				'filter' => FILTER_VALIDATE_INT,
-				'min_range' => 200,
-				'max_range' => 1000
+				'options' => [
+					'min_range' => 200,
+					'max_range' => 1000
+				]
 			],
 			'seo_metadata_default_image_height' => [
 				'filter' => FILTER_VALIDATE_INT,
-				'min_range' => 200,
-				'max_range' => 1000
+				'options' => [
+					'min_range' => 200,
+					'max_range' => 1000
+				]
 			],
 			'seo_metadata_default_image_type' => [
 				'filter' => FILTER_VALIDATE_REGEXP,
-				'regexp' => '#^image\/(?:jpe?g|png|gif)$#'
+				'options' => [
+					'regexp' => '#^image\/(?:jpe?g|png|gif)$#'
+				]
 			],
 			'seo_metadata_local_images' => [
 				'filter' => FILTER_VALIDATE_BOOLEAN
@@ -155,11 +169,12 @@ class acp
 			],
 			'seo_metadata_facebook_application' => [
 				'filter' => FILTER_VALIDATE_REGEXP,
-				'regexp' => '#^\d{10,25}$#'
+				'options' => [
+					'regexp' => '#^\d{10,25}$#'
+				]
 			],
 			'seo_metadata_facebook_publisher' => [
-				'filter' => FILTER_VALIDATE_REGEXP,
-				'regexp' => '#^https?://(?:www\.)?facebook\.com\/(?:pages\/)?[\w\.\-]+$#'
+				'filter' => FILTER_VALIDATE_URL
 			],
 
 			// Twitter Cards
@@ -168,7 +183,9 @@ class acp
 			],
 			'seo_metadata_twitter_publisher' => [
 				'filter' => FILTER_VALIDATE_REGEXP,
-				'regexp' => '#^\@[\w\.\-]+$#'
+				'options' => [
+					'regexp' => '#^\@[\w\.\-]+$#'
+				]
 			],
 
 			// JSON-LD

--- a/controller/acp.php
+++ b/controller/acp.php
@@ -389,6 +389,14 @@ class acp
 			// Validation check
 			if ($this->helper->validate($fields, $filters, $errors))
 			{
+				// Default image cleanup
+				if (empty($fields['seo_metadata_default_image']))
+				{
+					$fields['seo_metadata_default_image_type'] = '';
+					$fields['seo_metadata_default_image_width'] = 0;
+					$fields['seo_metadata_default_image_height'] = 0;
+				}
+
 				// Save configuration
 				foreach ($fields as $key => $value)
 				{
@@ -430,7 +438,7 @@ class acp
 			'SEO_METADATA_TWITTER_CARDS' => ((int) $this->config['seo_metadata_twitter_cards'] === 1),
 			'SEO_METADATA_TWITTER_PUBLISHER' => $this->config['seo_metadata_twitter_publisher'],
 			'SEO_METADATA_JSON_LD' => ((int) $this->config['seo_metadata_json_ld'] === 1),
-			'SERVER_NAME' => $this->config['server_name'],
+			'SERVER_NAME' => trim($this->config['server_name']),
 			'BOARD_IMAGES_URL' => generate_board_url() . '/images/'
 		]);
 

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -719,6 +719,55 @@ class helper
 	}
 
 	/**
+	 * Validate form fields with given filters.
+	 *
+	 * @param array $fields		Pair of field name and value
+	 * @param array $filters	Filters that will be passed to filter_var_array()
+	 * @param array $errors		Array of message errors
+	 *
+	 * @return bool
+	 */
+	public function validate(&$fields = [], &$filters = [], &$errors = [])
+	{
+		if (empty($fields) || empty($filters))
+		{
+			return false;
+		}
+
+		// Filter fields
+		$data = filter_var_array($fields, $filters, false);
+
+		// Invalid fields helper
+		$invalid = [];
+
+		// Validate fields
+		foreach ($data as $key => $value)
+		{
+			// Remove and generate error if field did not pass validation
+			// Not using empty() because an empty string can be a valid value
+			if (!isset($value) || $value === false)
+			{
+				$invalid[] = $this->language->lang(
+					sprintf('ACP_%s', strtoupper($key))
+				);
+				unset($fields[$key]);
+				continue;
+			}
+		}
+
+		if (!empty($invalid))
+		{
+			$errors[]['message'] = $this->language->lang(
+				'ACP_SEO_METADATA_VALIDATE_INVALID_FIELDS',
+				implode(', ', $invalid)
+			);
+		}
+
+		// Validation check
+		return empty($errors);
+	}
+
+	/**
 	 * Supported Open Graph locales.
 	 *
 	 * https://developers.facebook.com/docs/internationalization

--- a/language/en/acp/info_acp_settings.php
+++ b/language/en/acp/info_acp_settings.php
@@ -81,5 +81,7 @@ $lang = array_merge($lang, [
 	'ACP_JSON_LD_SETTINGS' => 'JSON-LD settings',
 	'ACP_JSON_LD' => 'Enable JSON-LD',
 
+	'ACP_SEO_METADATA_VALIDATE_INVALID_FIELDS' => 'Invalid values for fields: %s',
+
 	'LOG_SEO_METADATA_DATA' => '<strong>SEO Metadata data changed</strong><br>» %s'
 ]);

--- a/language/en/acp/info_acp_settings.php
+++ b/language/en/acp/info_acp_settings.php
@@ -45,9 +45,12 @@ $lang = array_merge($lang, [
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE' => 'Default image',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_EXPLAIN' => 'Default image URL for meta tags such as <samp>og:image</samp>. It will only be used if an image cannot be found within the current page. It must be larger than <samp>200</samp>x<samp>200</samp>px and relative to <samp>%s</samp>',
+	'ACP_SEO_METADATA_DEFAULT_IMAGE_INVALID' => 'The value specified as default image <samp>%1$s</samp> generated an empty URL. It could be due a non-existent image was specified or the file name was trying to go outside the <samp>/images/</samp> path.',
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_DIMENSIONS' => 'Default image dimensions',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_DIMENSIONS_EXPLAIN' => 'Width x height of default image. Set both to <samp>0</samp> to try to guess the image dimensions.',
+	'ACP_SEO_METADATA_DEFAULT_IMAGE_WIDTH' => 'Default image width',
+	'ACP_SEO_METADATA_DEFAULT_IMAGE_HEIGHT' => 'Default image height',
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_TYPE' => 'Default image type',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_TYPE_EXPLAIN' => 'The MIME type of default image. Leave it blank to try to guess the type, if you do not know this information or are unsure.',

--- a/language/en/acp/info_acp_settings.php
+++ b/language/en/acp/info_acp_settings.php
@@ -63,23 +63,23 @@ $lang = array_merge($lang, [
 
 	'ACP_SEO_METADATA_DATA_EXPLAIN' => 'Metadata are dynamically generated from your board data.',
 
-	'ACP_GLOBAL_SETTINGS' => 'Global settings',
+	'ACP_SEO_METADATA_GLOBAL_SETTINGS' => 'Global settings',
 
-	'ACP_OPEN_GRAPH_SETTINGS' => 'Open Graph settings',
-	'ACP_OPEN_GRAPH' => 'Enable Open Graph',
+	'ACP_SEO_METADATA_OPEN_GRAPH_SETTINGS' => 'Open Graph settings',
+	'ACP_SEO_METADATA_OPEN_GRAPH' => 'Enable Open Graph',
 
-	'ACP_FACEBOOK_APPLICATION' => 'Facebook application ID',
-	'ACP_FACEBOOK_APPLICATION_EXPLAIN' => 'Identifier of your Facebook application.',
-	'ACP_FACEBOOK_PUBLISHER' => 'Facebook publisher',
-	'ACP_FACEBOOK_PUBLISHER_EXPLAIN' => 'The URL of your Facebook page.',
+	'ACP_SEO_METADATA_FACEBOOK_APPLICATION' => 'Facebook application ID',
+	'ACP_SEO_METADATA_FACEBOOK_APPLICATION_EXPLAIN' => 'Identifier of your Facebook application.',
+	'ACP_SEO_METADATA_FACEBOOK_PUBLISHER' => 'Facebook publisher',
+	'ACP_SEO_METADATA_FACEBOOK_PUBLISHER_EXPLAIN' => 'The URL of your Facebook page.',
 
-	'ACP_TWITTER_CARD_SETTINGS' => 'Twitter Cards settings',
-	'ACP_TWITTER_CARDS' => 'Enable Twitter Cards',
-	'ACP_TWITTER_PUBLISHER' => 'Twitter publisher',
-	'ACP_TWITTER_PUBLISHER_EXPLAIN' => 'The username of your website Twitter account.',
+	'ACP_SEO_METADATA_TWITTER_CARD_SETTINGS' => 'Twitter Cards settings',
+	'ACP_SEO_METADATA_TWITTER_CARDS' => 'Enable Twitter Cards',
+	'ACP_SEO_METADATA_TWITTER_PUBLISHER' => 'Twitter publisher',
+	'ACP_SEO_METADATA_TWITTER_PUBLISHER_EXPLAIN' => 'The username of your website Twitter account.',
 
-	'ACP_JSON_LD_SETTINGS' => 'JSON-LD settings',
-	'ACP_JSON_LD' => 'Enable JSON-LD',
+	'ACP_SEO_METADATA_JSON_LD_SETTINGS' => 'JSON-LD settings',
+	'ACP_SEO_METADATA_JSON_LD' => 'Enable JSON-LD',
 
 	'ACP_SEO_METADATA_VALIDATE_INVALID_FIELDS' => 'Invalid values for fields: %s',
 

--- a/language/en/acp/info_acp_settings.php
+++ b/language/en/acp/info_acp_settings.php
@@ -45,7 +45,7 @@ $lang = array_merge($lang, [
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE' => 'Default image',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_EXPLAIN' => 'Default image URL for meta tags such as <samp>og:image</samp>. It will only be used if an image cannot be found within the current page. It must be larger than <samp>200</samp>x<samp>200</samp>px and relative to <samp>%s</samp>',
-	'ACP_SEO_METADATA_DEFAULT_IMAGE_INVALID' => 'The value specified as default image <samp>%1$s</samp> generated an empty URL. It could be due a non-existent image was specified or the file name was trying to go outside the <samp>/images/</samp> path.',
+	'ACP_SEO_METADATA_DEFAULT_IMAGE_INVALID' => 'The value specified as default image <samp>%1$s</samp> generated an empty URL.<br>It could be due a non-existent image was specified or the file name was trying to go outside the <samp>/images/</samp> path.',
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_DIMENSIONS' => 'Default image dimensions',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_DIMENSIONS_EXPLAIN' => 'Width x height of default image. Set both to <samp>0</samp> to try to guess the image dimensions.',

--- a/language/es/acp/info_acp_settings.php
+++ b/language/es/acp/info_acp_settings.php
@@ -45,9 +45,12 @@ $lang = array_merge($lang, [
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE' => 'Imagen por defecto',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_EXPLAIN' => 'URL de la imagen por defecto que será usada en metaetiquetas como <samp>og:image</samp>. Solo será usada si no se puede encontrar una imagen en la página actual. La imagen debe ser mayor a <samp>200</samp>x<samp>200</samp>px y su ruta debe ser relativa a <samp>%s</samp>',
+	'ACP_SEO_METADATA_DEFAULT_IMAGE_INVALID' => 'El valor especificado como imagen por defecto <samp>%1$s</samp> generó una URL vacía.<br>Pudo ser debido a que la imágen no existe o que el nombre de archivo intentó salir de la ruta <samp>/images/</samp>',
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_DIMENSIONS' => 'Dimensiones de la imagen por defecto',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_DIMENSIONS_EXPLAIN' => 'Ancho x alto de la imagen por defecto. Coloque <samp>0</samp> en ambos para intentar estimar sus dimensiones.',
+	'ACP_SEO_METADATA_DEFAULT_IMAGE_WIDTH' => 'Ancho de imagen por defecto',
+	'ACP_SEO_METADATA_DEFAULT_IMAGE_HEIGHT' => 'Alto de imagen por defecto',
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_TYPE' => 'Tipo de la imagen por defecto',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_TYPE_EXPLAIN' => 'El tipo de MIME de la imagen por defecto. Déjelo en blanco para intentar estimar el tipo, si no conoce esta información o no esta seguro.',
@@ -63,23 +66,25 @@ $lang = array_merge($lang, [
 
 	'ACP_SEO_METADATA_DATA_EXPLAIN' => 'Los metadatos son generados de manera dinámica usando los datos de su foro.',
 
-	'ACP_GLOBAL_SETTINGS' => 'Ajustes globales',
+	'ACP_SEO_METADATA_GLOBAL_SETTINGS' => 'Ajustes globales',
 
-	'ACP_OPEN_GRAPH_SETTINGS' => 'Ajustes de Open Graph',
-	'ACP_OPEN_GRAPH' => 'Habilitar Open Graph',
+	'ACP_SEO_METADATA_OPEN_GRAPH_SETTINGS' => 'Ajustes de Open Graph',
+	'ACP_SEO_METADATA_OPEN_GRAPH' => 'Habilitar Open Graph',
 
-	'ACP_FACEBOOK_APPLICATION' => 'ID de la applicación de Facebook',
-	'ACP_FACEBOOK_APPLICATION_EXPLAIN' => 'Identificador de su applicación de Facebook.',
-	'ACP_FACEBOOK_PUBLISHER' => 'Editor de Facebook',
-	'ACP_FACEBOOK_PUBLISHER_EXPLAIN' => 'La URL de su página de Facebook.',
+	'ACP_SEO_METADATA_FACEBOOK_APPLICATION' => 'ID de la applicación de Facebook',
+	'ACP_SEO_METADATA_FACEBOOK_APPLICATION_EXPLAIN' => 'Identificador de su applicación de Facebook.',
+	'ACP_SEO_METADATA_FACEBOOK_PUBLISHER' => 'Editor de Facebook',
+	'ACP_SEO_METADATA_FACEBOOK_PUBLISHER_EXPLAIN' => 'La URL de su página de Facebook.',
 
-	'ACP_TWITTER_CARD_SETTINGS' => 'Ajustes de Twitter Cards',
-	'ACP_TWITTER_CARDS' => 'Habilitar Twitter Cards',
-	'ACP_TWITTER_PUBLISHER' => 'Editor de Twitter',
-	'ACP_TWITTER_PUBLISHER_EXPLAIN' => 'El nombre de usuario de la cuenta de Twitter de su sitio web.',
+	'ACP_SEO_METADATA_TWITTER_CARD_SETTINGS' => 'Ajustes de Twitter Cards',
+	'ACP_SEO_METADATA_TWITTER_CARDS' => 'Habilitar Twitter Cards',
+	'ACP_SEO_METADATA_TWITTER_PUBLISHER' => 'Editor de Twitter',
+	'ACP_SEO_METADATA_TWITTER_PUBLISHER_EXPLAIN' => 'El nombre de usuario de la cuenta de Twitter de su sitio web.',
 
-	'ACP_JSON_LD_SETTINGS' => 'Ajustes de JSON-LD',
-	'ACP_JSON_LD' => 'Habilitar JSON-LD',
+	'ACP_SEO_METADATA_JSON_LD_SETTINGS' => 'Ajustes de JSON-LD',
+	'ACP_SEO_METADATA_JSON_LD' => 'Habilitar JSON-LD',
+
+	'ACP_SEO_METADATA_VALIDATE_INVALID_FIELDS' => 'Valores inválidos para los campos: %s',
 
 	'LOG_SEO_METADATA_DATA' => '<strong>Datos de Metadatos SEO modificados</strong><br>» %s'
 ]);

--- a/language/es_x_tu/acp/info_acp_settings.php
+++ b/language/es_x_tu/acp/info_acp_settings.php
@@ -45,9 +45,12 @@ $lang = array_merge($lang, [
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE' => 'Imagen por defecto',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_EXPLAIN' => 'URL de la imagen por defecto que será usada en metaetiquetas como <samp>og:image</samp>. Solo será usada si no se puede encontrar una imagen en la página actual. La imagen debe ser mayor a <samp>200</samp>x<samp>200</samp>px y su ruta debe ser relativa a <samp>%s</samp>',
+	'ACP_SEO_METADATA_DEFAULT_IMAGE_INVALID' => 'El valor especificado como imagen por defecto <samp>%1$s</samp> generó una URL vacía.<br>Pudo ser debido a que la imágen no existe o que el nombre de archivo intentó salir de la ruta <samp>/images/</samp>',
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_DIMENSIONS' => 'Dimensiones de la imagen por defecto',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_DIMENSIONS_EXPLAIN' => 'Ancho x alto de la imagen por defecto. Coloca <samp>0</samp> en ambos para intentar estimar sus dimensiones.',
+	'ACP_SEO_METADATA_DEFAULT_IMAGE_WIDTH' => 'Ancho de imagen por defecto',
+	'ACP_SEO_METADATA_DEFAULT_IMAGE_HEIGHT' => 'Alto de imagen por defecto',
 
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_TYPE' => 'Tipo de la imagen por defecto',
 	'ACP_SEO_METADATA_DEFAULT_IMAGE_TYPE_EXPLAIN' => 'El tipo de MIME de la imagen por defecto. Déjalo en blanco para intentar estimar el tipo, si no conoces esta información o no estas seguro.',
@@ -59,27 +62,29 @@ $lang = array_merge($lang, [
 	'ACP_SEO_METADATA_PREFER_ATTACHMENTS_EXPLAIN' => 'Las imágenes adjuntas tendrán mayor prioridad sobre las que han sido extraídas del mensaje.',
 
 	'ACP_SEO_METADATA_LOCAL_IMAGES' => 'Imágenes locales',
-	'ACP_SEO_METADATA_LOCAL_IMAGES_EXPLAIN' => 'Extrae imágenes del cuerpo del mensaje únicamente de tu dominio (<samp>%s</samp>).',
+	'ACP_SEO_METADATA_LOCAL_IMAGES_EXPLAIN' => 'Extrae imágenes del cuerpo del mensaje únicamente de su dominio (<samp>%s</samp>).',
 
-	'ACP_SEO_METADATA_DATA_EXPLAIN' => 'Los metadatos son generados de manera dinámica usando los datos de tu foro.',
+	'ACP_SEO_METADATA_DATA_EXPLAIN' => 'Los metadatos son generados de manera dinámica usando los datos de su foro.',
 
-	'ACP_GLOBAL_SETTINGS' => 'Ajustes globales',
+	'ACP_SEO_METADATA_GLOBAL_SETTINGS' => 'Ajustes globales',
 
-	'ACP_OPEN_GRAPH_SETTINGS' => 'Ajustes de Open Graph',
-	'ACP_OPEN_GRAPH' => 'Habilitar Open Graph',
+	'ACP_SEO_METADATA_OPEN_GRAPH_SETTINGS' => 'Ajustes de Open Graph',
+	'ACP_SEO_METADATA_OPEN_GRAPH' => 'Habilitar Open Graph',
 
-	'ACP_FACEBOOK_APPLICATION' => 'ID de la applicación de Facebook',
-	'ACP_FACEBOOK_APPLICATION_EXPLAIN' => 'Identificador de tu applicación de Facebook.',
-	'ACP_FACEBOOK_PUBLISHER' => 'Editor de Facebook',
-	'ACP_FACEBOOK_PUBLISHER_EXPLAIN' => 'La URL de tu página de Facebook.',
+	'ACP_SEO_METADATA_FACEBOOK_APPLICATION' => 'ID de la applicación de Facebook',
+	'ACP_SEO_METADATA_FACEBOOK_APPLICATION_EXPLAIN' => 'Identificador de tu applicación de Facebook.',
+	'ACP_SEO_METADATA_FACEBOOK_PUBLISHER' => 'Editor de Facebook',
+	'ACP_SEO_METADATA_FACEBOOK_PUBLISHER_EXPLAIN' => 'La URL de tu página de Facebook.',
 
-	'ACP_TWITTER_CARD_SETTINGS' => 'Ajustes de Twitter Cards',
-	'ACP_TWITTER_CARDS' => 'Habilitar Twitter Cards',
-	'ACP_TWITTER_PUBLISHER' => 'Editor de Twitter',
-	'ACP_TWITTER_PUBLISHER_EXPLAIN' => 'El nombre de usuario de la cuenta de Twitter de tu sitio web.',
+	'ACP_SEO_METADATA_TWITTER_CARD_SETTINGS' => 'Ajustes de Twitter Cards',
+	'ACP_SEO_METADATA_TWITTER_CARDS' => 'Habilitar Twitter Cards',
+	'ACP_SEO_METADATA_TWITTER_PUBLISHER' => 'Editor de Twitter',
+	'ACP_SEO_METADATA_TWITTER_PUBLISHER_EXPLAIN' => 'El nombre de usuario de la cuenta de Twitter de tu sitio web.',
 
-	'ACP_JSON_LD_SETTINGS' => 'Ajustes de JSON-LD',
-	'ACP_JSON_LD' => 'Habilitar JSON-LD',
+	'ACP_SEO_METADATA_JSON_LD_SETTINGS' => 'Ajustes de JSON-LD',
+	'ACP_SEO_METADATA_JSON_LD' => 'Habilitar JSON-LD',
+
+	'ACP_SEO_METADATA_VALIDATE_INVALID_FIELDS' => 'Valores inválidos para los campos: %s',
 
 	'LOG_SEO_METADATA_DATA' => '<strong>Datos de Metadatos SEO modificados</strong><br>» %s'
 ]);

--- a/styles/all/template/seo_metadata.html
+++ b/styles/all/template/seo_metadata.html
@@ -1,7 +1,7 @@
 {%- import '@alfredoramos_seometadata/metatag.html' as seo_metadata -%}
-{%- for CATEGORIES in SEO_METADATA -%}
-	{%- if CATEGORIES.NAME is same as('JSON_LD') -%}
-{%- if S_TOPIC_ID > 0 -%}
+{% for CATEGORIES in SEO_METADATA %}
+{% if CATEGORIES.NAME is same as('JSON_LD') %}
+{% if S_TOPIC_ID > 0 %}
 <script type="application/ld+json">
 {
 	{%- for ITEM in attribute(CATEGORIES, CATEGORIES.NAME) -%}
@@ -9,10 +9,10 @@
 	{%- endfor -%}
 }
 </script>
-{%- endif -%}
-	{%- else -%}
-		{%- for ITEM in attribute(CATEGORIES, CATEGORIES.NAME) -%}
-			{{- seo_metadata.metatag(ITEM.PROPERTY, ITEM.CONTENT) -}}
-		{%- endfor -%}
-	{%- endif -%}
-{%- endfor -%}
+{% endif %}
+{% else %}
+{% for ITEM in attribute(CATEGORIES, CATEGORIES.NAME) %}
+{{ seo_metadata.metatag(ITEM.PROPERTY, ITEM.CONTENT) -}}
+{% endfor %}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
- [x] Validate with `filter_var_array()`
- [x] Add validation error messages in the ACP settings page
- [x] Reimplement default image with, height and MIME type extraction/guess
- [x] Validate Facebook publisher as URL instead of string
- [x] Validate default image as URL too
- [x] Verify that optional using values are indeed optional
- [x] Discard default image if it has invalid MIME type
- [x] Discard Open Graph image dimensions and MIME type if URL is empty
- [x] Verify there are no missing language keys/values
- [x] Code cleanup
- [x] Update tests