### PR TITLE
Use htmlspecialchars() in helper::clean_url()

### DIFF
--- a/includes/helper.php
+++ b/includes/helper.php
@@ -601,7 +601,7 @@ class helper
 		}
 
 		// Escape ampersand
-		$url = str_replace(['&amp;', '&'], ['&', '&amp;'], $url);
+		$url = htmlspecialchars($url, ENT_COMPAT, 'UTF-8', false);
 
 		// Remove SID from URL
 		$url = str_replace($this->user->session_id, '', $url);


### PR DESCRIPTION
I did not use it before since the EPV was throwing a warning, but it seems to be allowed.

Reference:
- https://www.phpbb.com/community/viewtopic.php?p=15341221#p15341221