### PR TITLE
Prefix description with subject if body length <25

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -112,6 +112,20 @@ class listener implements EventSubscriberInterface
 		else
 		{
 			$data['description'] = $event['rowset'][$first_post_id]['post_text'];
+			// Prefix with post subject if body length is < 25 (+ 7 for <t>...</t>), to satisfy SEO recommendations
+			if (strlen($data['description']) < 32)
+			{
+				// Load XML document of post body
+				$dom = new \DOMDocument;
+				$dom->loadXML($data['description']);
+				// Prepend post subject to post body in XML
+				$dom->documentElement->insertBefore(
+					$dom->createTextNode($event['rowset'][$first_post_id]['post_subject'] . ': '),
+					$dom->documentElement->firstChild
+				);
+				// Save modified XML
+				$data['description'] = $dom->saveXML($dom->documentElement);
+			}
 		}
 
 		// Extract image


### PR DESCRIPTION
The post body text can be very short, in which case SEO recommendations may not be met, recommending description meta tag lengths of at least 25 characters. This change prefixes the description with the post subject, in case the body text is less than 25 characters long.