### PR TITLE
Add support for phpBB v4

### DIFF
--- a/.github/setup-extension.sh
+++ b/.github/setup-extension.sh
@@ -10,15 +10,15 @@ NOTESTS="${2}"
 composer update -n --prefer-dist --no-progress
 
 # Prepare extension structure
-mkdir -p ../phpBB3/phpBB/ext/"${EXTNAME}"
+mkdir -p ../phpbb/phpBB/ext/"${EXTNAME}"
 
 # Build extension package
 vendor/bin/phing
 
 # Copy extension files and directories
-cp -a build/package/"${EXTNAME}"/* ../phpBB3/phpBB/ext/"${EXTNAME}"/
+cp -a build/package/"${EXTNAME}"/* ../phpbb/phpBB/ext/"${EXTNAME}"/
 
 # Add required files for tests
 if [[ "${NOTESTS}" != 1 ]]; then
-	cp -a {phpunit.xml.dist,tests/} ../phpBB3/phpBB/ext/"${EXTNAME}"/
+	cp -a {phpunit.xml.dist,tests/} ../phpbb/phpBB/ext/"${EXTNAME}"/
 fi

--- a/.github/setup-tests.sh
+++ b/.github/setup-tests.sh
@@ -16,8 +16,8 @@ if [[ "${NOTESTS}" != 1 ]]; then
 	)
 
 	for image in "${images[@]}"; do
-		file=../phpBB3/phpBB/images/"${image}"
-		fixture=../phpBB3/phpBB/ext/"${EXTNAME}"/tests/functional/fixtures/images/"${image}"
+		file=../phpbb/phpBB/images/"${image}"
+		fixture=../phpbb/phpBB/ext/"${EXTNAME}"/tests/functional/fixtures/images/"${image}"
 
 		if [[ ! -f "${file}" ]]; then
 			cp "${fixture}" "$(dirname "${file}")"/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,26 +11,26 @@ env:
   IMAGE_ICC: 1
   EPV: 1
   EXECUTABLE_FILES: 1
-  PHPBB_BRANCH: 3.3.x
+  PHPBB_BRANCH: master
 
 jobs:
   basic-tests:
     if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
     name: php ${{ matrix.php-version }}, none none
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       PHP_VERSION: ${{ matrix.php-version }}
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1']
+        php-version: ['8.2']
     steps:
       - name: Checkout phpBB
         uses: actions/checkout@v6
         with:
           repository: phpbb/phpbb
           ref: ${{ env.PHPBB_BRANCH }}
-          path: phpBB3
+          path: phpbb
 
       - name: Checkout extension
         uses: actions/checkout@v6
@@ -47,7 +47,7 @@ jobs:
 
       - name: Setup Composer
         id: setup-composer
-        working-directory: phpBB3/phpBB
+        working-directory: phpbb/phpBB
         run: echo "cache-dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Setup cache
@@ -59,7 +59,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Setup environment for phpBB
-        working-directory: phpBB3
+        working-directory: phpbb
         run: .github/setup-phpbb.sh $DB $PHP_VERSION $NOTESTS
 
       - name: Setup extension
@@ -70,33 +70,33 @@ jobs:
 
       - name: Setup EPV
         if: ${{ env.EPV == 1 }}
-        working-directory: phpBB3/phpBB
+        working-directory: phpbb/phpBB
         run: composer require -n --prefer-dist --no-progress phpbb/epv:dev-master
 
       - name: Run code sniffer
         if: ${{ env.SNIFF == 1 }}
-        working-directory: phpBB3
+        working-directory: phpbb
         run: .github/ext-sniff.sh $EXTNAME $NOTESTS
 
       - name: Check image ICC profiles
         if: ${{ env.IMAGE_ICC == 1 }}
-        working-directory: phpBB3
+        working-directory: phpbb
         run: .github/check-image-icc-profiles.sh
 
       - name: Check executable files
         if: ${{ env.EXECUTABLE_FILES == 1 }}
-        working-directory: phpBB3
+        working-directory: phpbb
         run: .github/ext-check-executable-files.sh ./ $EXTNAME
 
       - name: Run EPV
         if: ${{ env.EPV == 1 }}
-        working-directory: phpBB3
+        working-directory: phpbb
         run: phpBB/vendor/bin/EPV.php run --dir="phpBB/ext/$EXTNAME"
 
   mysql-tests:
     if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
     name: php ${{ matrix.php-version }}, ${{ matrix.db-type }} ${{ matrix.db-version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     services:
       mysql:
         image: ${{ (matrix.db-type == 'mysql' || matrix.db-type == 'mariadb') && matrix.db-type || 'mariadb' }}:${{ (matrix.db-type == 'mysql' || matrix.db-type == 'mariadb' && matrix.db-version != 'none') && matrix.db-version || 'latest' }}
@@ -118,12 +118,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php-version: '8.1'
+          - php-version: '8.2'
             db-type: 'mysql'
             db-version: '5.7'
-          - php-version: '8.1'
-            db-type: 'mariadb'
-            db-version: '10.6'
           - php-version: '8.2'
             db-type: 'mariadb'
             db-version: '10.6'
@@ -142,7 +139,7 @@ jobs:
         with:
           repository: phpbb/phpbb
           ref: ${{ env.PHPBB_BRANCH }}
-          path: phpBB3
+          path: phpbb
 
       - name: Checkout extension
         uses: actions/checkout@v6
@@ -159,7 +156,7 @@ jobs:
 
       - name: Setup Composer
         id: setup-composer
-        working-directory: phpBB3/phpBB
+        working-directory: phpbb/phpBB
         run: echo "cache-dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Setup cache
@@ -171,7 +168,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Setup environment for phpBB
-        working-directory: phpBB3
+        working-directory: phpbb
         run: .github/setup-phpbb.sh $DB $PHP_VERSION $NOTESTS
 
       - name: Setup extension
@@ -181,11 +178,11 @@ jobs:
           .github/setup-extension.sh $EXTNAME $NOTESTS
 
       - name: Setup database
-        working-directory: phpBB3
+        working-directory: phpbb
         run: .github/setup-database.sh $DB $MYISAM
 
       - name: Setup PHPUnit files
-        working-directory: phpBB3
+        working-directory: phpbb
         run: |
           mkdir -p phpBB/ext/$EXTNAME/ci
           cp -a .github/phpunit* phpBB/ext/$EXTNAME/ci/
@@ -197,13 +194,13 @@ jobs:
           .github/setup-tests.sh $EXTNAME $NOTESTS
 
       - name: Run unit tests
-        working-directory: phpBB3
+        working-directory: phpbb
         run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$EXTNAME/ci/phpunit-$DB-github.xml --bootstrap tests/bootstrap.php
 
   postgresql-tests:
     if: ${{ !contains(github.event.head_commit.message, 'skip ci') }}
     name: php ${{ matrix.php-version }}, ${{ matrix.db-type }} ${{ matrix.db-version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: ${{ (matrix.db-type == 'postgres') && matrix.db-type || 'postgres' }}:${{ (matrix.db-type == 'postgres' && matrix.db-version != 'none') && matrix.db-version || 'alpine' }}
@@ -226,7 +223,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php-version: '8.1'
+          - php-version: '8.2'
             db-type: 'postgres'
             db-version: '17-alpine'
           - php-version: '8.4'
@@ -241,7 +238,7 @@ jobs:
         with:
           repository: phpbb/phpbb
           ref: ${{ env.PHPBB_BRANCH }}
-          path: phpBB3
+          path: phpbb
 
       - name: Checkout extension
         uses: actions/checkout@v6
@@ -258,7 +255,7 @@ jobs:
 
       - name: Setup Composer
         id: setup-composer
-        working-directory: phpBB3/phpBB
+        working-directory: phpbb/phpBB
         run: echo "cache-dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Setup cache
@@ -270,7 +267,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Setup environment for phpBB
-        working-directory: phpBB3
+        working-directory: phpbb
         run: .github/setup-phpbb.sh $DB $PHP_VERSION $NOTESTS
 
       - name: Setup extension
@@ -280,11 +277,11 @@ jobs:
           .github/setup-extension.sh $EXTNAME $NOTESTS
 
       - name: Setup database
-        working-directory: phpBB3
+        working-directory: phpbb
         run: .github/setup-database.sh $DB $MYISAM
 
       - name: Setup PHPUnit files
-        working-directory: phpBB3
+        working-directory: phpbb
         run: |
           mkdir -p phpBB/ext/$EXTNAME/ci
           cp -a .github/phpunit* phpBB/ext/$EXTNAME/ci/
@@ -296,5 +293,5 @@ jobs:
           .github/setup-tests.sh $EXTNAME $NOTESTS
 
       - name: Run unit tests
-        working-directory: phpBB3
+        working-directory: phpbb
         run: phpBB/vendor/bin/phpunit --configuration phpBB/ext/$EXTNAME/ci/phpunit-$DB-github.xml --bootstrap tests/bootstrap.php

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ If available, it will dynamically generate and include the following data inside
 
 ### Requirements
 
-- PHP 8.1 or greater
-- phpBB 3.3 or greater
+- PHP 8.2 or greater
+- phpBB 4.0 or greater
 
 ### Support
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		}
 	],
 	"require": {
-		"php": "^8.1.0",
+		"php": "^8.2.0",
 		"composer/installers": "^2.2.0"
 	},
 	"require-dev": {
@@ -38,7 +38,7 @@
 	"extra": {
 		"display-name": "SEO Metadata",
 		"soft-require": {
-			"phpbb/phpbb": "~3.3.0"
+			"phpbb/phpbb": "~4.0.0"
 		},
 		"version-check": {
 			"host": "alfredoramos.mx",

--- a/ext.php
+++ b/ext.php
@@ -14,12 +14,10 @@ use phpbb\extension\base;
 class ext extends base
 {
 	/**
-	 * Check whether or not the extension can be enabled.
-	 *
-	 * @return bool
+	 * {@inheritdoc}
 	 */
 	public function is_enableable()
 	{
-		return phpbb_version_compare(PHPBB_VERSION, '3.3.0', '>=');
+		return phpbb_version_compare(PHPBB_VERSION, '4.0.0-a1-dev', '>='); // TODO: Use stable version
 	}
 }

--- a/tests/functional/seometadata_test.php
+++ b/tests/functional/seometadata_test.php
@@ -26,7 +26,7 @@ class seometadata_test extends \phpbb_functional_test_case
 
 		$this->assertSame(1, $element->count());
 		$this->assertSame(
-			'This is an example post in your phpBB3 installation. Everything seems to be working. You may delete this post if you like and continue to set up your board. Dur',
+			'This is an example post in your phpBB installation. Everything seems to be working. You may delete this post if you like and continue to set up your board. Duri',
 			$element->attr('content')
 		);
 	}
@@ -88,11 +88,11 @@ class seometadata_test extends \phpbb_functional_test_case
 			$elements['type']->attr('content')
 		);
 		$this->assertSame(
-			'Welcome to phpBB3',
+			'Welcome to phpBB',
 			$elements['title']->attr('content')
 		);
 		$this->assertSame(
-			'This is an example post in your phpBB3 installation. Everything seems to be working. You may delete this post if you like and continue to set up your board. Dur',
+			'This is an example post in your phpBB installation. Everything seems to be working. You may delete this post if you like and continue to set up your board. Duri',
 			$elements['description']->attr('content')
 		);
 		$this->assertSame(
@@ -154,11 +154,11 @@ class seometadata_test extends \phpbb_functional_test_case
 			$elements['site']->attr('content')
 		);
 		$this->assertSame(
-			'Welcome to phpBB3',
+			'Welcome to phpBB',
 			$elements['title']->attr('content')
 		);
 		$this->assertSame(
-			'This is an example post in your phpBB3 installation. Everything seems to be working. You may delete this post if you like and continue to set up your board. Dur',
+			'This is an example post in your phpBB installation. Everything seems to be working. You may delete this post if you like and continue to set up your board. Duri',
 			$elements['description']->attr('content')
 		);
 		$this->assertSame(
@@ -200,15 +200,15 @@ class seometadata_test extends \phpbb_functional_test_case
 			))
 		);
 		$this->assertSame(
-			'Welcome to phpBB3',
+			'Welcome to phpBB',
 			$elements['headline']
 		);
 		$this->assertSame(
-			'This is an example post in your phpBB3 installation. Everything seems to be working. You may delete this post if you like and continue to set up your board. Dur',
+			'This is an example post in your phpBB installation. Everything seems to be working. You may delete this post if you like and continue to set up your board. Duri',
 			$elements['description']
 		);
 		$this->assertSame(
-			'This is an example post in your phpBB3 installation. Everything seems to be working. You may delete this post if you like and continue to set up your board. Dur',
+			'This is an example post in your phpBB installation. Everything seems to be working. You may delete this post if you like and continue to set up your board. Duri',
 			$elements['text']
 		);
 		$this->assertSame(
@@ -569,12 +569,12 @@ class seometadata_test extends \phpbb_functional_test_case
 		];
 
 		$this->assertSame(
-			'Welcome to phpBB3 Post reply test',
+			'Welcome to phpBB Post reply test',
 			$elements['meta_description']->attr('content')
 		);
 
 		$this->assertSame(
-			'Welcome to phpBB3 Post reply test',
+			'Welcome to phpBB Post reply test',
 			$elements['open_graph']['description']->attr('content')
 		);
 		$this->assertSame(
@@ -586,7 +586,7 @@ class seometadata_test extends \phpbb_functional_test_case
 		$this->assertSame('image/jpeg', $elements['open_graph']['type']->attr('content'));
 
 		$this->assertSame(
-			'Welcome to phpBB3 Post reply test',
+			'Welcome to phpBB Post reply test',
 			$elements['twitter_cards']['description']->attr('content')
 		);
 		$this->assertSame(


### PR DESCRIPTION
- [ ] Fix `TODO` comments
  - [ ] Tests
  - [x] CI workflow
- [ ] Update required tests in repository settings
  - [x] Remove tests for PHP < 8.1
  - [x] Add missing tests for PHP >= 8.1
- [ ] Merge when phpBB v4.0.0 is released
- [ ] Update README
- [ ] Fix `phpBB3` routes in CI workflow