### PR TITLE
Added datePublished field to comment schema to fix GSC warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ If available, it will dynamically generate and include the following data inside
 		"@type": "Comment",
 		"identifier": "...",
 		"text": "...",
+		"datePublished": "...",
 		"author": {
 			"@type": "Person",
 			"name": "...",

--- a/event/listener.php
+++ b/event/listener.php
@@ -137,6 +137,12 @@ class listener implements EventSubscriberInterface
 		{
 			return;
 		}
+   
+        $iso_date = '';
+		if (!empty($event['row']['post_time']))
+		{
+			$iso_date = date('c', (int) $event['row']['post_time']);
+		}
 
 		// Meta data helper
 		$data = [];
@@ -145,7 +151,8 @@ class listener implements EventSubscriberInterface
 		$data['comment'] = [
 			'identifier' => $this->helper->generate_post_url($event['row']['post_id']),
 			'text' => $this->helper->clean_post_data($event['row']['post_text']),
-			'author' => $this->helper->extract_author($event['row']['username'], $event['row']['user_id'])
+			'author' => $this->helper->extract_author($event['row']['username'], $event['row']['user_id']),
+			'datePublished' => $iso_date
 		];
 
 		$this->helper->set_metadata($data);

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -305,15 +305,17 @@ class helper
 
 				case 'comment':
 					if (isset($value['text'], $value['identifier']))
-					{
+					{          
 						$data = [
 							'identifier' => $value['identifier'],
 							'text' => $value['text'],
+                            'datePublished' => $value['datePublished'] ?? '',
 						];
 						$default = [
 							'@type' => 'Comment',
 							'identifier' => '',
 							'text' => '',
+							'datePublished' => '',
 							'author' => [
 								'@type' => 'Person',
 								'name' => '',


### PR DESCRIPTION
This PR fixes the Google Search Console warning: **"Field 'datePublished' missing (in 'comment')"**.

Currently, the `DiscussionForumPosting` schema for replies (comments) lacks the required timestamp, which causes warnings in GSC.

### Changes
* **`event/listener.php`**: Extracted the `post_time` from the event row. If available, it is formatted as an ISO 8601 string. If the timestamp is missing, the field remains empty (to avoid invalid data).
* **`includes/helper.php`**: Updated the logic to pass the `datePublished` field through to the final JSON output.

### Result
The generated JSON-LD now correctly includes the `datePublished` property for forum replies. If a post time is not available, the property is omitted entirely to prevent errors, effectively resolving the GSC validation warning.

Fixes #125